### PR TITLE
Add graphviz as a runtime dependency

### DIFF
--- a/fpgrowth-ruby.gemspec
+++ b/fpgrowth-ruby.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "ruby-graphviz"
+  spec.add_dependency "ruby-graphviz"
 end


### PR DESCRIPTION
graphviz is required as a development dependency. So without having graphviz already installed, loading fpgrowth will fail:

    /usr/local/lib/ruby/gems/2.7.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require': cannot load such file -- graphviz (LoadError)